### PR TITLE
_format_name should return some value so as not to issue uuv warnings

### DIFF
--- a/lib/TAP/Formatter/Pretty/Multi.pm
+++ b/lib/TAP/Formatter/Pretty/Multi.pm
@@ -79,6 +79,7 @@ sub _format_name {
     $self->_output(" <$periods\n");
     $self->_set_colors('reset');
 
+    return ''; # as pretty format name has already been written
 }
 
 1;


### PR DESCRIPTION
Use of uninitialized value $_[0] in print at C:/strawberry/perl/lib/TAP/Formatter/Base.pm line 404. の件の対策です。色がつかない環境でないと出力する内容に色コードなどが追加されてしまうので再現しないと思いますが、ご確認くださいませ。
