### PR TITLE
Check $builder->{No_Plan} before showing 'Bad plan'

### DIFF
--- a/lib/Test/Pretty.pm
+++ b/lib/Test/Pretty.pm
@@ -128,7 +128,7 @@ if ((!$ENV{HARNESS_ACTIVE} || $ENV{PERL_TEST_PRETTY_ENABLED})) {
 END {
     my $builder = Test::Builder->new;
     my $real_exit_code = $?;
-    if ($builder->{Have_Plan}) {
+    if ($builder->{Have_Plan} && !$builder->{No_Plan}) {
         if ($builder->{Curr_Test} != $builder->{Expected_Tests}) {
             $builder->diag("Bad plan: $builder->{Curr_Test} != $builder->{Expected_Tests}");
             $builder->is_passing(0);


### PR DESCRIPTION
I want to avoid showing 'Bad plans' in this test case.

``` perl
use strict;
use warnings;
use Test::Pretty;
use Test::LoadAllModules;

BEGIN {
    all_uses_ok(
        search_path => 'BabaSiF',
    );
}
```
