### PR TITLE
Allow config of name color

### DIFF
--- a/lib/Test/Pretty.pm
+++ b/lib/Test/Pretty.pm
@@ -224,7 +224,7 @@ ERR
 
     if( defined $name ) {
         $name =~ s|#|\\#|g;    # # in a name can confuse Test::Harness.
-        $out .= colored(['BRIGHT_BLACK'], "  $name");
+        $out .= colored([$ENV{TEST_PRETTY_COLOR_NAME} || 'BRIGHT_BLACK'], "  $name");
         $result->{name} = $name;
     }
     else {


### PR DESCRIPTION
I use solarized color theme in iTerm2, and the `BRIGHT_BLACK` (for different reasons) is the same as the background color. Added a simple change to allow me to set the color from the envionment.

I wasn't sure how to write tests for color things, but I can do that if you have some tips :)
