### PR TITLE
Need to colour output if running under App::Prove harness and Pretty plugin is enabled

### DIFF
--- a/lib/Test/Pretty.pm
+++ b/lib/Test/Pretty.pm
@@ -14,7 +14,7 @@ use Carp ();
 
 use Cwd ();
 
-*colored = -t STDOUT ? \&Term::ANSIColor::colored : sub { $_[1] };
+*colored = -t STDOUT || $ENV{PERL_TEST_PRETTY_ENABLED} ? \&Term::ANSIColor::colored : sub { $_[1] };
 
 my $SHOW_DUMMY_TAP;
 my $TERM_ENCODING = Term::Encoding::term_encoding();


### PR DESCRIPTION
This was the previous behavior.

On a side note, it might be a good idea to add an example using the plugin with ~/.proverc in the documentation:
    -Pretty
