### PR TITLE
care the eval

### DIFF
--- a/lib/Test/Pretty.pm
+++ b/lib/Test/Pretty.pm
@@ -38,6 +38,7 @@ my $get_src_line = sub {
             or return '';
         [<$fh>]
     }->();
+    return unless ref $lines eq 'ARRAY';
     my $line = $lines->[$lineno-1];
     $line =~ s/^\s+|\s+$//g;
     return $line;

--- a/t/eval.t
+++ b/t/eval.t
@@ -1,0 +1,18 @@
+use utf8;
+use strict;
+use warnings;
+use Test::More;
+
+eval "is(filename_is_eval(__FILE__), 1, "
+    . "'eval(...) should pick up eval filename')";
+is( $@, '', 'no eval error on previous test' );
+
+done_testing;
+
+sub filename_is_eval($) {
+    my $filename = shift;
+    return 0 unless defined $filename;
+
+    return !!( $filename =~ /^\(eval \d+\)|-e$/
+        || $filename =~ /^sub \S+::\S+/ );
+}


### PR DESCRIPTION
Fix for error Can't use string ("") as an ARRAY ref while "strict refs"
in use … Test/Pretty.pm line 41.
