### PR TITLE
Change the position to reset color

### DIFF
--- a/lib/TAP/Formatter/Pretty/Multi.pm
+++ b/lib/TAP/Formatter/Pretty/Multi.pm
@@ -44,8 +44,10 @@ sub _set_colors {
 sub _output_success {
     my ( $self, $msg ) = @_;
     $self->_set_colors('green');
+    my $has_newline = chomp $msg;
     $self->_output($msg);
     $self->_set_colors('reset');
+    $self->_output($/) if $has_newline;
 }
 
 sub _failure_output {
@@ -76,8 +78,9 @@ sub _format_name {
     $self->_set_colors('cyan');
     $self->_output("$name");
     $self->_set_colors('yellow');
-    $self->_output(" <$periods\n");
+    $self->_output(" <$periods");
     $self->_set_colors('reset');
+    $self->_output("\n");
 
     return ''; # as pretty format name has already been written
 }


### PR DESCRIPTION
If we look the result of test with `tail -f` or similar command,
then protrude the setting of color to next line. Like so;
![http://i.gyazo.com/4301e1f57fe02998b13d45bbafc5970e.png](http://i.gyazo.com/4301e1f57fe02998b13d45bbafc5970e.png)

So I fix this.
![http://i.gyazo.com/c24cb7c795a6693d51ea9bf7a0f421eb.png](http://i.gyazo.com/c24cb7c795a6693d51ea9bf7a0f421eb.png)
