### PR TITLE
Implemented new Test::* paradigm

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -11,7 +11,7 @@ requires 'TAP::Parser';
 requires 'autodie';
 requires 'parent';
 requires 'perl', '5.008001';
-requires 'Test::More', '0.98';
+requires 'Test::More', '1.301001';
 
 on test => sub {
     requires 'Test::Requires';

--- a/lib/Test/Pretty.pm
+++ b/lib/Test/Pretty.pm
@@ -164,7 +164,7 @@ Test::Stream->shared->follow_up( sub {
         }
     }
 
-    if ($SHOW_DUMMY_TAP and !$called_by_done_testing) {
+    if ($SHOW_DUMMY_TAP) {
        $ctx->dummy_tap(($?==0 && $stream->is_passing));
     }
 });

--- a/lib/Test/Pretty.pm
+++ b/lib/Test/Pretty.pm
@@ -255,7 +255,8 @@ sub ok_to_tap {
        $src_line = '';
    }
 
-   my $name = $e->name || "  L" . $context->line . ": ". $src_line;
+   $src_line = ( $src_line ) ? ": ". $src_line : "";
+   my $name = $e->name || "  L" . $context->line . $src_line;
    @sets = $e->to_tap;
 
    unless($e->real_bool) {

--- a/lib/Test/Pretty.pm
+++ b/lib/Test/Pretty.pm
@@ -271,7 +271,7 @@ sub ok_to_tap {
    if (defined($context->line)) {
        $src_line = $get_src_line->($context->file, $context->line);
    } else {
-      #diag(Carp::longmess("\$Test::Builder::Level is invalid. Testing library you are using is broken. : $Test::Builder::Level"));
+      $context->diag(Carp::longmess("\$Test::Builder::Level is invalid. Testing library you are using is broken. : $Test::Builder::Level"));
        $src_line = '';
    }
 

--- a/lib/Test/Pretty.pm
+++ b/lib/Test/Pretty.pm
@@ -229,8 +229,6 @@ sub stream_listener {
     $DEBUG && print STDERR "type: " . lc($type) . "\n";
     $DEBUG && print STDERR "=> In Subtest (". $e->in_subtest. ")\n" if $e->in_subtest;
 
-    my $context = $e->context;
-
     my @sets;
 
     if ($e->isa('Test::Stream::Event::Subtest')) {
@@ -238,8 +236,8 @@ sub stream_listener {
            #return if $e->[EXCEPTION]
            #       && $e->[EXCEPTION]->isa('Test::Stream::Event::Bail');
 
-            # Subtest is a subclass of Ok, use Ok's to_tap method:
-            return $e->Test::Stream::Event::Ok::to_tap(undef);
+           # Subtest is a subclass of Ok, use Ok's to_tap method:
+           return ok_to_tap($e);
         }
 
         # Subtest final result first
@@ -250,40 +248,63 @@ sub stream_listener {
             #[OUT_STD, "}\n"],
         );
     } elsif ( $e->isa('Test::Stream::Event::Ok') ) {
-        my $name = $e->name || "  L" . $context->line . ": ". $context->file;
-        @sets = $e->to_tap;
-
-        my $out;
-
-        unless($e->real_bool) {
-            my $fail_char = $ENCODING_IS_UTF8 ? "\x{2716}" : "x";
-            $out .= colored(['red'], $fail_char);
-        }
-        else {
-            my $success_char = $ENCODING_IS_UTF8 ? "\x{2713}" : "o";
-            $out .= colored(['green'], $success_char);
-        }
-
-        # Add name
-        if( defined $name ) {
-            $name =~ s|#|\\#|g;    # # in a name can confuse Test::Harness.
-            $out .= colored([$ENV{TEST_PRETTY_COLOR_NAME} || 'BRIGHT_BLACK'], "  $name");
-        }
-
-        $out .= "\n";
-
-        # Replace STDOUT
-        for my $set ( @sets ) {
-            if ( $set->[0] == OUT_STD ) {
-                $set = [
-                    OUT_STD, $out,
-                ];
-                last;
-            }
-        }
+       @sets = ok_to_tap($e);
     }
 
     return @sets;
+}
+
+=head2 ok_to_tap
+
+C<ok_to_tap> is the "pretty" version of Test::Stream::Event::Ok's C<to_tap>.
+
+=cut
+
+sub ok_to_tap {
+   my $e = shift;
+
+   my $context = $e->context;
+
+   my ( $out, @sets );
+
+   my $src_line;
+   if (defined($context->line)) {
+       $src_line = $get_src_line->($context->file, $context->line);
+   } else {
+      #diag(Carp::longmess("\$Test::Builder::Level is invalid. Testing library you are using is broken. : $Test::Builder::Level"));
+       $src_line = '';
+   }
+
+   my $name = $e->name || "  L" . $context->line . ": ". $src_line;
+   @sets = $e->to_tap;
+
+   unless($e->real_bool) {
+       my $fail_char = $ENCODING_IS_UTF8 ? "\x{2716}" : "x";
+       $out .= colored(['red'], $fail_char);
+   }
+   else {
+       my $success_char = $ENCODING_IS_UTF8 ? "\x{2713}" : "o";
+       $out .= colored(['green'], $success_char);
+   }
+
+   # Add name
+   if( defined $name ) {
+       $name =~ s|#|\\#|g;    # # in a name can confuse Test::Harness.
+       $out .= colored([$ENV{TEST_PRETTY_COLOR_NAME} || 'BRIGHT_BLACK'], "  $name");
+   }
+
+   $out .= "\n";
+
+   # Replace STDOUT
+   for my $set ( @sets ) {
+       if ( $set->[0] == OUT_STD ) {
+           $set = [
+               OUT_STD, $out,
+           ];
+           last;
+       }
+   }
+   return @sets;
 }
 
 sub _skip_all {

--- a/lib/Test/Pretty.pm
+++ b/lib/Test/Pretty.pm
@@ -260,6 +260,9 @@ sub stream_listener {
                 OUT_STD, "1..0 # SKIP ". $e->reason . "\n",
           ] );
        }
+    } else {
+       return unless $e->can('to_tap');
+       @sets = $e->to_tap();
     }
 
     return @sets;

--- a/lib/Test/Pretty.pm
+++ b/lib/Test/Pretty.pm
@@ -4,7 +4,12 @@ use warnings;
 use 5.008001;
 our $VERSION = '0.32';
 
-use Test::Builder 0.82;
+use Test::Stream (
+    subtest_tap => 'delayed',
+    'OUT_STD',
+    'OUT_ERR',
+    'OUT_TODO',
+);
 
 # Conditionally load Windows Term encoding
 use if $^O eq 'MSWin32', 'Win32::Console::ANSI';
@@ -22,9 +27,13 @@ use Cwd ();
 
 my $ORIGINAL_PID = $$;
 
+$ENV{TEST_PRETTY_INDENT} ||= '    ';
+
 my $SHOW_DUMMY_TAP;
 my $TERM_ENCODING = Term::Encoding::term_encoding();
 my $ENCODING_IS_UTF8 = $TERM_ENCODING =~ /^utf-?8$/i;
+
+my $DEBUG = 1;
 
 our $NO_ENDING; # Force disable the Test::Pretty finalization process.
 
@@ -52,51 +61,60 @@ my $get_src_line = sub {
 
 if ((!$ENV{HARNESS_ACTIVE} || $ENV{PERL_TEST_PRETTY_ENABLED})) {
     # make pretty
-    no warnings 'redefine';
-    *Test::Builder::subtest = \&_subtest;
-    *Test::Builder::ok = \&_ok;
-    *Test::Builder::done_testing = \&_done_testing;
-    *Test::Builder::skip = \&_skip;
-    *Test::Builder::skip_all = \&_skip_all;
-    *Test::Builder::expected_tests = \&_expected_tests;
+    
+    #*Test::Builder::subtest = \&_subtest;
+    #*Test::Builder::ok = \&_ok;
+    #*Test::Builder::done_testing = \&_done_testing;
+    #*Test::Builder::skip = \&_skip;
+    #*Test::Builder::skip_all = \&_skip_all;
+    #*Test::Builder::expected_tests = \&_expected_tests;
 
-    my %plan_cmds = (
-        no_plan     => \&Test::Builder::no_plan,
-        skip_all    => \&_skip_all,
-        tests       => \&__plan_tests,
-    );
-    *Test::Builder::plan = sub {
-        my( $self, $cmd, $arg ) = @_;
+    # Use Test::Stream
+    # Turn off normal TAP output
+    Test::Stream->shared->set_use_tap(0);
 
-        return unless $cmd;
+    # Turn off legacy storage of results.
+    Test::Stream->shared->set_use_legacy(0);
 
-        local $Test::Builder::Level = $Test::Builder::Level + 1;
+    Test::Stream->shared->listen(\&stream_listener);
 
-        $self->croak("You tried to plan twice") if $self->{Have_Plan};
+    # my %plan_cmds = (
+    #     no_plan     => \&Test::Builder::no_plan,
+    #     skip_all    => \&_skip_all,
+    #     tests       => \&__plan_tests,
+    # );
+    # *Test::Builder::plan = sub {
+    #     my( $self, $cmd, $arg ) = @_;
 
-        if( my $method = $plan_cmds{$cmd} ) {
-            local $Test::Builder::Level = $Test::Builder::Level + 1;
-            $self->$method($arg);
-        }
-        else {
-            my @args = grep { defined } ( $cmd, $arg );
-            $self->croak("plan() doesn't understand @args");
-        }
+    #     return unless $cmd;
 
-        return 1;
-    };
+    #     local $Test::Builder::Level = $Test::Builder::Level + 1;
 
-    my $builder = Test::Builder->new;
-    $builder->no_ending(1);
-    $builder->no_header(1); # plan
+    #     $self->croak("You tried to plan twice") if $self->{Have_Plan};
 
-    binmode $builder->output(), "encoding($TERM_ENCODING)";
-    binmode $builder->failure_output(), "encoding($TERM_ENCODING)";
-    binmode $builder->todo_output(), "encoding($TERM_ENCODING)";
+    #     if( my $method = $plan_cmds{$cmd} ) {
+    #         local $Test::Builder::Level = $Test::Builder::Level + 1;
+    #         $self->$method($arg);
+    #     }
+    #     else {
+    #         my @args = grep { defined } ( $cmd, $arg );
+    #         $self->croak("plan() doesn't understand @args");
+    #     }
 
-    if ($ENV{HARNESS_ACTIVE}) {
-        $SHOW_DUMMY_TAP++;
-    }
+    #     return 1;
+    # };
+
+    # my $builder = Test::Builder->new;
+    # $builder->no_ending(1);
+    # $builder->no_header(1); # plan
+
+    # binmode $builder->output(), "encoding($TERM_ENCODING)";
+    # binmode $builder->failure_output(), "encoding($TERM_ENCODING)";
+    # binmode $builder->todo_output(), "encoding($TERM_ENCODING)";
+
+    # if ($ENV{HARNESS_ACTIVE}) {
+    #     $SHOW_DUMMY_TAP++;
+    # }
 } else {
     no warnings 'redefine';
     my $ORIGINAL_ok = \&Test::Builder::ok;
@@ -179,6 +197,76 @@ END {
         }
     }
 NO_ENDING:
+}
+
+sub stream_listener {
+    my ($stream, $e) = @_;
+
+    $DEBUG && print STDERR "---- event ----\n";
+    my $type = blessed $e;
+    $type =~ s/^.*:://g;
+    $DEBUG && print STDERR "type: " . lc($type) . "\n";
+    $DEBUG && print STDERR "=> In Subtest (". $e->in_subtest. ")\n" if $e->in_subtest;
+
+    my $context = $e->context;
+
+    my @sets;
+
+    if ($e->isa('Test::Stream::Event::Subtest')) {
+        # Subtest is a subclass of Ok, use Ok's to_tap method:
+        #print STDERR "e->to_tap(): ".Dumper($e->to_tap(undef, $stream->subtest_tap_delayed))."\n";
+        #@sets = subtest_render_events($e, undef, $stream->subtest_tap_delayed);
+        #$e->context->stream->listen(\&stream_listener);
+        @sets = $e->to_tap(undef, $stream->subtest_tap_delayed);
+    } elsif ( $e->isa('Test::Stream::Event::Ok') ) {
+        my $name = $e->name || "  L" . $context->line . ": ". $context->file;
+        @sets = $e->to_tap;
+
+        my $out;
+
+        unless($e->real_bool) {
+            my $fail_char = $ENCODING_IS_UTF8 ? "\x{2716}" : "x";
+            $out .= colored(['red'], $fail_char);
+        }
+        else {
+            my $success_char = $ENCODING_IS_UTF8 ? "\x{2713}" : "o";
+            $out .= colored(['green'], $success_char);
+        }
+
+        # Add name
+        if( defined $name ) {
+            $name =~ s|#|\\#|g;    # # in a name can confuse Test::Harness.
+            $out .= colored([$ENV{TEST_PRETTY_COLOR_NAME} || 'BRIGHT_BLACK'], "  $name");
+        }
+
+        $out .= "\n";
+
+        # Replace STDOUT
+        for my $set ( @sets ) {
+            if ( $set->[0] == OUT_STD ) {
+                $set = [
+                    OUT_STD, $out,
+                ];
+            }
+        }
+    }
+
+    for my $set (@sets) {
+        my ($hid, $msg) = @$set;
+        next unless $msg;
+        my $enc = $e->encoding || die "Could not find encoding!";
+
+        # This is how you get the proper handle to use (STDERR, STDOUT, ETC).
+        my $io = $stream->io_sets->{$enc}->[$hid] || die "Could not find IO $hid for $enc";
+
+        # Make sure we don't alter these vars.
+        local($\, $", $,) = (undef, ' ', '');
+
+        # Otherwise we get "Wide character in print" errors.
+        binmode $io, "encoding($TERM_ENCODING)";
+        # print to the IO
+        print $io $msg;
+    }
 }
 
 sub _skip_all {
@@ -331,6 +419,24 @@ sub _subtest {
     my $retval = $ORIGINAL_subtest->(@_);
     *Test::Builder::note = $ORIGINAL_note;
     $retval;
+}
+sub subtest_render_events {
+    my $self = shift;
+    my ($num, $delayed) = @_;
+
+    my $idx = 0;
+    my @out;
+    for my $e (@{$self->events}) {
+        next unless $e->can('to_tap');
+        $idx++ if $e->isa('Test::Stream::Event::Ok');
+        push @out => $e->to_tap($idx, $delayed);
+    }
+
+    for my $set (@out) {
+        $set->[1] =~ s/^/$ENV{TEST_PRETTY_INDENT}/mg;
+    }
+
+    return @out;
 }
 
 sub __plan_tests {

--- a/lib/Test/Pretty.pm
+++ b/lib/Test/Pretty.pm
@@ -13,6 +13,8 @@ use Test::Stream (
 
 # Conditionally load Windows Term encoding
 use if $^O eq 'MSWin32', 'Win32::Console::ANSI';
+
+use Test::Stream::Event::DummyTap;
 use Term::Encoding ();
 
 use File::Spec ();
@@ -61,13 +63,6 @@ my $get_src_line = sub {
 
 if ((!$ENV{HARNESS_ACTIVE} || $ENV{PERL_TEST_PRETTY_ENABLED})) {
     # make pretty
-    
-    #*Test::Builder::subtest = \&_subtest;
-    #*Test::Builder::ok = \&_ok;
-    #*Test::Builder::done_testing = \&_done_testing;
-    #*Test::Builder::skip = \&_skip;
-    #*Test::Builder::skip_all = \&_skip_all;
-    #*Test::Builder::expected_tests = \&_expected_tests;
 
     # Use Test::Stream
     # Turn off normal TAP output
@@ -98,40 +93,6 @@ if ((!$ENV{HARNESS_ACTIVE} || $ENV{PERL_TEST_PRETTY_ENABLED})) {
            print $io $msg;
        }
     });
-
-    # my %plan_cmds = (
-    #     no_plan     => \&Test::Builder::no_plan,
-    #     skip_all    => \&_skip_all,
-    #     tests       => \&__plan_tests,
-    # );
-    # *Test::Builder::plan = sub {
-    #     my( $self, $cmd, $arg ) = @_;
-
-    #     return unless $cmd;
-
-    #     local $Test::Builder::Level = $Test::Builder::Level + 1;
-
-    #     $self->croak("You tried to plan twice") if $self->{Have_Plan};
-
-    #     if( my $method = $plan_cmds{$cmd} ) {
-    #         local $Test::Builder::Level = $Test::Builder::Level + 1;
-    #         $self->$method($arg);
-    #     }
-    #     else {
-    #         my @args = grep { defined } ( $cmd, $arg );
-    #         $self->croak("plan() doesn't understand @args");
-    #     }
-
-    #     return 1;
-    # };
-
-    # my $builder = Test::Builder->new;
-    # $builder->no_ending(1);
-    # $builder->no_header(1); # plan
-
-    # binmode $builder->output(), "encoding($TERM_ENCODING)";
-    # binmode $builder->failure_output(), "encoding($TERM_ENCODING)";
-    # binmode $builder->todo_output(), "encoding($TERM_ENCODING)";
 
     if ($ENV{HARNESS_ACTIVE}) {
         $SHOW_DUMMY_TAP++;
@@ -179,11 +140,10 @@ if ((!$ENV{HARNESS_ACTIVE} || $ENV{PERL_TEST_PRETTY_ENABLED})) {
     };
 }
 
-END {
-    my $stream = Test::Stream->shared;
+Test::Stream->shared->follow_up( sub {
+    my ($ctx) = @_;
+    my $stream = $ctx->stream;
     my $real_exit_code = $?;
-
-    my $ctx = Test::Stream::Context::context(undef, $stream);
 
     # Don't bother with an ending if this is a forked copy.  Only the parent
     # should do the ending.
@@ -207,7 +167,12 @@ END {
         }
     }
     if ($SHOW_DUMMY_TAP) {
-        printf("\n%s\n", ($?==0 && $stream->is_passing) ? 'ok' : 'not ok');
+       $ctx->dummy_tap(($?==0 && $stream->is_passing));
+       #my $set = $stream->io_sets->init_encoding('legacy');
+       #my $std = $set->[0];
+       ##print STDERR "set->[0]: ".Dumper($set->[0])."\n";
+       #my $ok = ($?==0 && $stream->is_passing) ? 'ok' : 'not ok';
+       #printf $std "\n%s\n", $ok;
     }
     if (!$real_exit_code) {
         if ($stream->is_passing) {
@@ -220,7 +185,7 @@ END {
         }
     }
 NO_ENDING:
-}
+});
 
 sub stream_listener {
     my ($stream, $e) = @_;
@@ -330,157 +295,6 @@ sub ok_to_tap {
    return @sets;
 }
 
-sub _skip_all {
-    my ($self, $reason) = @_;
-
-    $self->{Skip_All} = $self->parent ? $reason : 1;
-
-    $self->_print("1..0 # SKIP" . " $reason");
-    $SHOW_DUMMY_TAP = 0;
-    if ( $self->parent ) {
-        die bless {} => 'Test::Builder::Exception';
-    }
-    exit(0);
-}
-
-sub _ok {
-    my( $self, $test, $name ) = @_;
-
-    my ($pkg, $filename, $line, $sub) = caller($Test::Builder::Level);
-    my $src_line;
-    if (defined($line)) {
-        $src_line = $get_src_line->($filename, $line);
-    } else {
-        $self->diag(Carp::longmess("\$Test::Builder::Level is invalid. Testing library you are using is broken. : $Test::Builder::Level"));
-        $src_line = '';
-    }
-
-    if ( $self->{Child_Name} and not $self->{In_Destroy} ) {
-        $name = 'unnamed test' unless defined $name;
-        $self->is_passing(0);
-        $self->croak("Cannot run test ($name) with active children");
-    }
-    # $test might contain an object which we don't want to accidentally
-    # store, so we turn it into a boolean.
-    $test = $test ? 1 : 0;
-
-    lock $self->{Curr_Test};
-    $self->{Curr_Test}++;
-
-    # In case $name is a string overloaded object, force it to stringify.
-    $self->_unoverload_str( \$name );
-
-    $self->diag(<<"ERR") if defined $name and $name =~ /^[\d\s]+$/;
-    You named your test '$name'.  You shouldn't use numbers for your test names.
-    Very confusing.
-ERR
-
-    # Capture the value of $TODO for the rest of this ok() call
-    # so it can more easily be found by other routines.
-    my $todo    = $self->todo();
-    my $in_todo = $self->in_todo;
-    local $self->{Todo} = $todo if $in_todo;
-
-    $self->_unoverload_str( \$todo );
-
-    my $out;
-    my $result = &Test::Builder::share( {} );
-
-
-    unless($test) {
-        my $fail_char = $ENCODING_IS_UTF8 ? "\x{2716}" : "x";
-        $out .= colored(['red'], $fail_char);
-        @$result{ 'ok', 'actual_ok' } = ( ( $self->in_todo ? 1 : 0 ), 0 );
-    }
-    else {
-        my $success_char = $ENCODING_IS_UTF8 ? "\x{2713}" : "o";
-        $out .= colored(['green'], $success_char);
-        @$result{ 'ok', 'actual_ok' } = ( 1, $test );
-    }
-
-    $name ||= "  L$line: $src_line";
-
-    # $out .= " $self->{Curr_Test}" if $self->use_numbers;
-
-    if( defined $name ) {
-        $name =~ s|#|\\#|g;    # # in a name can confuse Test::Harness.
-        $out .= colored([$ENV{TEST_PRETTY_COLOR_NAME} || 'BRIGHT_BLACK'], "  $name");
-        $result->{name} = $name;
-    }
-    else {
-        $result->{name} = '';
-    }
-
-    if( $self->in_todo ) {
-        $out .= " # TODO $todo";
-        $result->{reason} = $todo;
-        $result->{type}   = 'todo';
-    }
-    else {
-        $result->{reason} = '';
-        $result->{type}   = '';
-    }
-
-    $self->{Test_Results}[ $self->{Curr_Test} - 1 ] = $result;
-    $out .= "\n";
-
-    # Dont print 'ok's for subtests. It's not pretty.
-    $self->_print($out) unless $sub =~/subtest/ and $test;
-
-    unless($test) {
-        my $msg = $self->in_todo ? "Failed (TODO)" : "Failed";
-        $self->_print_to_fh( $self->_diag_fh, "\n" ) if $ENV{HARNESS_ACTIVE};
-
-        my( undef, $file, $line ) = $self->caller;
-        if( defined $name ) {
-            $self->diag(qq[  $msg test '$name'\n]);
-            $self->diag(qq[  at $file line $line.\n]);
-        }
-        else {
-            $self->diag(qq[  $msg test at $file line $line.\n]);
-        }
-    }
-
-    $self->is_passing(0) unless $test || $self->in_todo;
-
-    # Check that we haven't violated the plan
-    $self->_check_is_passing_plan();
-
-    return $test ? 1 : 0;
-}
-
-sub _done_testing {
-    # do nothing
-    my $builder = Test::More->builder;
-    $builder->{Have_Plan} = 1;
-    $builder->{Done_Testing} = [caller];
-    $builder->{Expected_Tests} = $builder->current_test;
-}
-
-sub _subtest {
-    my ($self, $name) = @_;
-    my $orig_indent = $self->_indent();
-    my $ORIGINAL_note = \&Test::Builder::note;
-    no warnings 'redefine';
-    *Test::Builder::note = sub {
-        # Not sure why the output looses its encoding but lets set it back again.
-        # Otherwise we get "Wide character in print" errors.
-        binmode $_[0]->output(), "encoding($TERM_ENCODING)";
-        # If printing the beginning of a subtest, make it pretty
-        if ( $_[1] eq "Subtest: $name") {
-            print {$self->output} do {
-                 $orig_indent . "  $name\n";
-            };
-            return 0;
-        } else {
-            $ORIGINAL_note->(@_);
-        }
-    };
-    # Now that we've redefined note(), let Test::Builder run as normal.
-    my $retval = $ORIGINAL_subtest->(@_);
-    *Test::Builder::note = $ORIGINAL_note;
-    $retval;
-}
 sub subtest_render_events {
     my ($stream, $e) = @_;
 
@@ -497,60 +311,6 @@ sub subtest_render_events {
     }
 
     return @out;
-}
-
-sub __plan_tests {
-    my ( $self, $arg ) = @_;
-
-    if ($arg) {
-        local $Test::Builder::Level = $Test::Builder::Level + 1;
-        return $self->expected_tests($arg);
-    }
-    elsif ( !defined $arg ) {
-        $self->croak("Got an undefined number of tests");
-    }
-    else {
-        $self->croak("You said to run 0 tests");
-    }
-
-    return;
-}
-
-sub _expected_tests {
-    my $self = shift;
-    my($max) = @_;
-
-    if(@_) {
-        $self->croak("Number of tests must be a positive integer.  You gave it '$max'")
-          unless $max =~ /^\+?\d+$/;
-
-        $self->{Expected_Tests} = $max;
-        $self->{Have_Plan}      = 1;
-
-        # $self->_output_plan($max) unless $self->no_header;
-    }
-    return $self->{Expected_Tests};
-}
-
-sub _skip {
-    my ($self, $why) = @_;
-
-    lock( $self->{Curr_Test} );
-    $self->{Curr_Test}++;
-
-    $self->{Test_Results}[ $self->{Curr_Test} - 1 ] = &Test::Builder::share(
-        {
-            'ok'      => 1,
-            actual_ok => 1,
-            name      => '',
-            type      => 'skip',
-            reason    => $why,
-        }
-    );
-
-    $self->_print(colored(['yellow'], 'skip') . " $why");
-
-    return 1;
 }
 
 1;

--- a/lib/Test/Pretty.pm
+++ b/lib/Test/Pretty.pm
@@ -152,10 +152,10 @@ Test::Stream->shared->follow_up( sub {
     # Don't bother with an ending if this is a forked copy.  Only the parent
     # should do the ending.
     if( $ORIGINAL_PID!= $$ or $in_subtest) {
-        goto NO_ENDING;
+        return;
     }
     if ($Test::Pretty::NO_ENDING) {
-        goto NO_ENDING;
+        return;
     }
 
     # see Test::Builder::_ending
@@ -188,7 +188,6 @@ Test::Stream->shared->follow_up( sub {
             $? = 1;
         }
     }
-NO_ENDING:
 });
 
 sub stream_listener {

--- a/lib/Test/Pretty.pm
+++ b/lib/Test/Pretty.pm
@@ -179,10 +179,11 @@ if ((!$ENV{HARNESS_ACTIVE} || $ENV{PERL_TEST_PRETTY_ENABLED})) {
     };
 }
 
-Test::Stream->shared->follow_up( sub {
-    my ($ctx) = @_;
-    my $stream = $ctx->stream;
+END {
+    my $stream = Test::Stream->shared;
     my $real_exit_code = $?;
+
+    my $ctx = Test::Stream::Context::context(undef, $stream);
 
     # Don't bother with an ending if this is a forked copy.  Only the parent
     # should do the ending.
@@ -219,7 +220,7 @@ Test::Stream->shared->follow_up( sub {
         }
     }
 NO_ENDING:
-});
+}
 
 sub stream_listener {
     my ($stream, $e) = @_;

--- a/lib/Test/Pretty.pm
+++ b/lib/Test/Pretty.pm
@@ -5,7 +5,7 @@ use 5.008001;
 our $VERSION = '0.32';
 
 use Test::Stream (
-    subtest_tap => 'delayed',
+   #subtest_tap => 'delayed',
     'OUT_STD',
     'OUT_ERR',
     'OUT_TODO',
@@ -33,7 +33,7 @@ my $SHOW_DUMMY_TAP;
 my $TERM_ENCODING = Term::Encoding::term_encoding();
 my $ENCODING_IS_UTF8 = $TERM_ENCODING =~ /^utf-?8$/i;
 
-my $DEBUG = 1;
+my $DEBUG = 0;
 
 our $NO_ENDING; # Force disable the Test::Pretty finalization process.
 
@@ -76,7 +76,28 @@ if ((!$ENV{HARNESS_ACTIVE} || $ENV{PERL_TEST_PRETTY_ENABLED})) {
     # Turn off legacy storage of results.
     Test::Stream->shared->set_use_legacy(0);
 
-    Test::Stream->shared->listen(\&stream_listener);
+    Test::Stream->shared->listen(sub {
+       my ($stream, $e) = @_;
+       my @sets = stream_listener($stream, $e);
+
+       # Render output
+       for my $set (@sets) {
+           my ($hid, $msg) = @$set;
+           next unless $msg;
+           my $enc = $e->encoding || die "Could not find encoding!";
+
+           # This is how you get the proper handle to use (STDERR, STDOUT, ETC).
+           my $io = $stream->io_sets->{$enc}->[$hid] || die "Could not find IO $hid for $enc";
+
+           # Make sure we don't alter these vars.
+           local($\, $", $,) = (undef, ' ', '');
+
+           # Otherwise we get "Wide character in print" errors.
+           binmode $io, "encoding($TERM_ENCODING)";
+           # print to the IO
+           print $io $msg;
+       }
+    });
 
     # my %plan_cmds = (
     #     no_plan     => \&Test::Builder::no_plan,
@@ -213,11 +234,21 @@ sub stream_listener {
     my @sets;
 
     if ($e->isa('Test::Stream::Event::Subtest')) {
-        # Subtest is a subclass of Ok, use Ok's to_tap method:
-        #print STDERR "e->to_tap(): ".Dumper($e->to_tap(undef, $stream->subtest_tap_delayed))."\n";
-        #@sets = subtest_render_events($e, undef, $stream->subtest_tap_delayed);
-        #$e->context->stream->listen(\&stream_listener);
-        @sets = $e->to_tap(undef, $stream->subtest_tap_delayed);
+        unless($stream->subtest_tap_delayed) {
+           #return if $e->[EXCEPTION]
+           #       && $e->[EXCEPTION]->isa('Test::Stream::Event::Bail');
+
+            # Subtest is a subclass of Ok, use Ok's to_tap method:
+            return $e->Test::Stream::Event::Ok::to_tap(undef);
+        }
+
+        # Subtest final result first
+        @sets = (
+           [ OUT_STD, $e->name . "\n" ], # Render the subtests name
+            subtest_render_events($stream, $e),
+            #$e->_render_events(@_),
+            #[OUT_STD, "}\n"],
+        );
     } elsif ( $e->isa('Test::Stream::Event::Ok') ) {
         my $name = $e->name || "  L" . $context->line . ": ". $context->file;
         @sets = $e->to_tap;
@@ -247,26 +278,12 @@ sub stream_listener {
                 $set = [
                     OUT_STD, $out,
                 ];
+                last;
             }
         }
     }
 
-    for my $set (@sets) {
-        my ($hid, $msg) = @$set;
-        next unless $msg;
-        my $enc = $e->encoding || die "Could not find encoding!";
-
-        # This is how you get the proper handle to use (STDERR, STDOUT, ETC).
-        my $io = $stream->io_sets->{$enc}->[$hid] || die "Could not find IO $hid for $enc";
-
-        # Make sure we don't alter these vars.
-        local($\, $", $,) = (undef, ' ', '');
-
-        # Otherwise we get "Wide character in print" errors.
-        binmode $io, "encoding($TERM_ENCODING)";
-        # print to the IO
-        print $io $msg;
-    }
+    return @sets;
 }
 
 sub _skip_all {
@@ -421,15 +438,14 @@ sub _subtest {
     $retval;
 }
 sub subtest_render_events {
-    my $self = shift;
-    my ($num, $delayed) = @_;
+    my ($stream, $e) = @_;
 
     my $idx = 0;
     my @out;
-    for my $e (@{$self->events}) {
+    for my $e (@{$e->events}) {
         next unless $e->can('to_tap');
         $idx++ if $e->isa('Test::Stream::Event::Ok');
-        push @out => $e->to_tap($idx, $delayed);
+        push @out => stream_listener($stream, $e);
     }
 
     for my $set (@out) {

--- a/lib/Test/Pretty.pm
+++ b/lib/Test/Pretty.pm
@@ -183,7 +183,7 @@ END {
     my $stream = Test::Stream->shared;
     my $real_exit_code = $?;
 
-    my $ctx = Test::Stream::Context::context();
+    my $ctx = Test::Stream::Context::context(undef, $stream);
 
     # Don't bother with an ending if this is a forked copy.  Only the parent
     # should do the ending.
@@ -202,7 +202,7 @@ END {
 
     if ( $stream->plan && !( $stream->plan->directive && $stream->plan->directive eq 'NO PLAN' ) ) {
         if ($stream->count != $stream->plan->max) {
-            $ctx->diag("Bad plan: $stream->count != $stream->plan->max");
+            $ctx->diag("Bad plan: " . $stream->count . " != " . $stream->plan->max);
             $stream->is_passing(0);
         }
     }

--- a/lib/Test/Pretty.pm
+++ b/lib/Test/Pretty.pm
@@ -5,7 +5,6 @@ use 5.008001;
 our $VERSION = '0.32';
 
 use Test::Stream (
-   #subtest_tap => 'delayed',
     'OUT_STD',
     'OUT_ERR',
     'OUT_TODO',
@@ -35,11 +34,7 @@ my $SHOW_DUMMY_TAP;
 my $TERM_ENCODING = Term::Encoding::term_encoding();
 my $ENCODING_IS_UTF8 = $TERM_ENCODING =~ /^utf-?8$/i;
 
-my $DEBUG = 0;
-
 our $NO_ENDING; # Force disable the Test::Pretty finalization process.
-
-my $ORIGINAL_subtest = \&Test::Builder::subtest;
 
 our $BASE_DIR = Cwd::getcwd();
 my %filecache;
@@ -169,24 +164,14 @@ Test::Stream->shared->follow_up( sub {
             $stream->is_passing(0);
         }
     }
+
     if ($SHOW_DUMMY_TAP and !$called_by_done_testing) {
        $ctx->dummy_tap(($?==0 && $stream->is_passing));
-       #my $set = $stream->io_sets->init_encoding('legacy');
-       #my $std = $set->[0];
-       ##print STDERR "set->[0]: ".Dumper($set->[0])."\n";
-       #my $ok = ($?==0 && $stream->is_passing) ? 'ok' : 'not ok';
-       #printf $std "\n%s\n", $ok;
     }
 });
 
 sub stream_listener {
     my ($stream, $e) = @_;
-
-    $DEBUG && print STDERR "---- event ----\n";
-    my $type = blessed $e;
-    $type =~ s/^.*:://g;
-    $DEBUG && print STDERR "type: " . lc($type) . "\n";
-    $DEBUG && print STDERR "=> In Subtest (". $e->in_subtest. ")\n" if $e->in_subtest;
 
     my @sets;
 
@@ -203,8 +188,6 @@ sub stream_listener {
         @sets = (
            [ OUT_STD, $e->name . "\n" ], # Render the subtests name
             subtest_render_events($stream, $e),
-            #$e->_render_events(@_),
-            #[OUT_STD, "}\n"],
         );
     } elsif ( $e->isa('Test::Stream::Event::Ok') ) {
        @sets = ok_to_tap($e);

--- a/lib/Test/Pretty.pm
+++ b/lib/Test/Pretty.pm
@@ -249,6 +249,15 @@ sub stream_listener {
         );
     } elsif ( $e->isa('Test::Stream::Event::Ok') ) {
        @sets = ok_to_tap($e);
+    } elsif ( $e->isa('Test::Stream::Event::Plan') ) {
+
+       # IF the plan is a skip all
+       if ($e->directive eq 'SKIP') {
+          $SHOW_DUMMY_TAP = 0;
+          @sets = ( [
+                OUT_STD, "1..0 # SKIP ". $e->reason . "\n",
+          ] );
+       }
     }
 
     return @sets;

--- a/lib/Test/Pretty.pm
+++ b/lib/Test/Pretty.pm
@@ -267,6 +267,15 @@ sub ok_to_tap {
 
    my ( $out, @sets );
 
+   # If skipped, render "skip" followed by the reason why.
+   if ( $e->skip ) {
+      return (
+         [
+            OUT_STD, colored(['yellow'], 'skip') . " " . $e->skip . "\n",
+         ]
+      );
+   }
+
    my $src_line;
    if (defined($context->line)) {
        $src_line = $get_src_line->($context->file, $context->line);

--- a/lib/Test/Pretty.pm
+++ b/lib/Test/Pretty.pm
@@ -5,6 +5,7 @@ use 5.008001;
 our $VERSION = '0.32';
 
 use Test::Stream (
+    subtest_tap => 'delayed',
     'OUT_STD',
     'OUT_ERR',
     'OUT_TODO',

--- a/lib/Test/Pretty.pm
+++ b/lib/Test/Pretty.pm
@@ -141,7 +141,7 @@ Test::Stream->shared->follow_up( sub {
     my $stream = $ctx->stream;
     my $real_exit_code = $?;
 
-    my $called_by_done_testing = ( $ctx->subname and $ctx->subname eq 'Test::More::done_testing' );
+    my $called_by_done_testing = not $ctx->isa('Test::Stream::ExitMagic::Context' );
 
     # Don't bother with an ending if this is a forked copy.  Only the parent
     # should do the ending.

--- a/lib/Test/Pretty.pm
+++ b/lib/Test/Pretty.pm
@@ -143,11 +143,9 @@ Test::Stream->shared->follow_up( sub {
 
     my $called_by_done_testing = ( $ctx->subname and $ctx->subname eq 'Test::More::done_testing' );
 
-    my $in_subtest = ( $ctx->subname and $ctx->subname eq 'Test::Stream::Subtest::subtest' );
-
     # Don't bother with an ending if this is a forked copy.  Only the parent
     # should do the ending.
-    if( $ORIGINAL_PID!= $$ or $in_subtest) {
+    if( $ORIGINAL_PID!= $$ ) {
         return;
     }
     if ($Test::Pretty::NO_ENDING) {

--- a/lib/Test/Pretty.pm
+++ b/lib/Test/Pretty.pm
@@ -161,7 +161,6 @@ Test::Stream->shared->follow_up( sub {
     # see Test::Builder::_ending
     if( !$stream->plan and $stream->count and !$called_by_done_testing) {
         $stream->is_passing(0);
-        $ctx->diag("Tests were run but no plan was declared and done_testing() was not seen.");
     }
 
     if ( $stream->plan && !( $stream->plan->directive && $stream->plan->directive eq 'NO PLAN' ) ) {
@@ -177,16 +176,6 @@ Test::Stream->shared->follow_up( sub {
        ##print STDERR "set->[0]: ".Dumper($set->[0])."\n";
        #my $ok = ($?==0 && $stream->is_passing) ? 'ok' : 'not ok';
        #printf $std "\n%s\n", $ok;
-    }
-    if (!$real_exit_code) {
-        if ($stream->is_passing) {
-            ## no critic (Variables::RequireLocalizedPunctuationVars)
-            $? = 0;
-        } else {
-            # TODO: exit status may be 'how many failed'
-            ## no critic (Variables::RequireLocalizedPunctuationVars)
-            $? = 1;
-        }
     }
 });
 

--- a/lib/Test/Pretty.pm
+++ b/lib/Test/Pretty.pm
@@ -179,11 +179,10 @@ if ((!$ENV{HARNESS_ACTIVE} || $ENV{PERL_TEST_PRETTY_ENABLED})) {
     };
 }
 
-END {
-    my $stream = Test::Stream->shared;
+Test::Stream->shared->follow_up( sub {
+    my ($ctx) = @_;
+    my $stream = $ctx->stream;
     my $real_exit_code = $?;
-
-    my $ctx = Test::Stream::Context::context(undef, $stream);
 
     # Don't bother with an ending if this is a forked copy.  Only the parent
     # should do the ending.
@@ -220,7 +219,7 @@ END {
         }
     }
 NO_ENDING:
-}
+});
 
 sub stream_listener {
     my ($stream, $e) = @_;

--- a/lib/Test/Pretty.pm
+++ b/lib/Test/Pretty.pm
@@ -133,9 +133,9 @@ if ((!$ENV{HARNESS_ACTIVE} || $ENV{PERL_TEST_PRETTY_ENABLED})) {
     # binmode $builder->failure_output(), "encoding($TERM_ENCODING)";
     # binmode $builder->todo_output(), "encoding($TERM_ENCODING)";
 
-    # if ($ENV{HARNESS_ACTIVE}) {
-    #     $SHOW_DUMMY_TAP++;
-    # }
+    if ($ENV{HARNESS_ACTIVE}) {
+        $SHOW_DUMMY_TAP++;
+    }
 } else {
     no warnings 'redefine';
     my $ORIGINAL_ok = \&Test::Builder::ok;

--- a/lib/Test/Stream/Event/DummyTap.pm
+++ b/lib/Test/Stream/Event/DummyTap.pm
@@ -8,11 +8,6 @@ use Test::Stream::Event(
    ctx_method => 'dummy_tap',
 );
 
-sub init {
-   my $self = shift;
-   $self->SUPER::init();
-}
-
 sub to_tap {
    my $self = shift;
 
@@ -24,7 +19,9 @@ sub to_tap {
 sub extra_details {
    my $self = shift;
 
-   return $self->SUPER::extra_details();
+   return (
+      succeed => $self->succeed || 0,
+   );
 }
 
 1;

--- a/lib/Test/Stream/Event/DummyTap.pm
+++ b/lib/Test/Stream/Event/DummyTap.pm
@@ -1,0 +1,32 @@
+package Test::Stream::Event::DummyTap;
+
+use strict;
+use warnings;
+
+use Test::Stream::Event(
+   accessors => [qw/succeed/],
+   ctx_method => 'dummy_tap',
+);
+
+sub init {
+   my $self = shift;
+   $self->SUPER::init();
+}
+
+sub to_tap {
+   my $self = shift;
+
+   my $ok = ($self->succeed) ? 'ok' : 'not ok';
+
+   return [ OUT_STD, "$ok\n", ];
+}
+
+sub extra_details {
+   my $self = shift;
+
+   return $self->SUPER::extra_details();
+}
+
+1;
+
+__END__

--- a/lib/Test/Stream/Event/DummyTap.pm
+++ b/lib/Test/Stream/Event/DummyTap.pm
@@ -18,7 +18,7 @@ sub to_tap {
 
    my $ok = ($self->succeed) ? 'ok' : 'not ok';
 
-   return [ OUT_STD, "$ok\n", ];
+   return [ OUT_STD, "\n$ok\n", ];
 }
 
 sub extra_details {

--- a/t/Util.pm
+++ b/t/Util.pm
@@ -35,8 +35,8 @@ sub run_test {
         return $out;
     } else {
         # child
-        open(STDOUT, ">", $filename) or die "Cannot redirect";
-        open(STDERR, ">", $filename) or die "Cannot redirect";
+        open(STDOUT, ">>", $filename) or die "Cannot redirect";
+        open(STDERR, ">>", $filename) or die "Cannot redirect";
         exec $^X, '-Ilib', '-MTest::Pretty', $path;
         die "Cannot exec";
     }

--- a/t/dummy-tap.t
+++ b/t/dummy-tap.t
@@ -1,0 +1,44 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::Stream::API qw/ context /;
+use Test::Stream::Tester;
+
+use_ok('Test::Stream::Event::DummyTap');
+
+events_are(
+   intercept {
+      my $ctx = context();
+      $ctx->dummy_tap(1);
+      $ctx->dummy_tap(0);
+      $ctx->dummy_tap();
+   },
+   #Expected results
+   check {
+      event dummytap => { succeed => 1, };
+      event dummytap => { succeed => 0, };
+      event dummytap => { succeed => 0, };
+      directive 'end';
+   },
+   'events are generated correctly'
+);
+
+subtest 'rendering' => sub {
+   my $successful_dummy_tap;
+   my $failed_dummy_tap;
+
+   my $events = intercept {
+      my $ctx = context;
+      $successful_dummy_tap = $ctx->dummy_tap(1);
+      $failed_dummy_tap = $ctx->dummy_tap(0);
+   };
+
+   is_deeply( $successful_dummy_tap->to_tap, [
+      0, "\nok\n",
+   ], 'Successful Dummy Tap renders correctly' );
+   is_deeply( $failed_dummy_tap->to_tap, [
+      0, "\nnot ok\n",
+   ], 'Failed Dummy Tap renders correctly' );
+};
+
+done_testing


### PR DESCRIPTION
I rewrote `Test::Pretty` to use the new `Test::Stream` API in `Test::More`'s alphas. So far all tests pass with Test::More 1.301001_084. Note that the rewrite is not backwards compatible. If it needs to be, let me know and I'll update the PR.

The code has been structured so that all events emitted by a stream are processed via `stream_listener()`. This way tests can be printed recursively (e.g. subtests). `stream_listener()` adds "pretty" output for 3 different events:
1. `subtest` events are printed as "pretty" `ok()`s if subtests are not set to 'delayed'. Otherwise they print their name and then recurse through their child tests. They do not end with an `ok()` anymore.
2. `ok` events are printed same as before.
3. `plan` events are printed if they are a `SKIP`. The rest are ignored.

Everything else is delegated to it's default rendering.

Closes #25 

_Notes:_
- Added `TEST_PRETTY_INDENT` env variable to set indention
- `subtest` names are no longer half indented.
- To differentiate between a "pretty" ok and the dummy tap, I created a new event called `Test::Stream::Event::DummyTap` which outputs the same dummy tap as before. This utilizes the same filehandle as `Test::More` instead of directly writing to `STDOUT`.
- Removed code that set the exit code so that `Test::More` can do that for us.
- Todo items inside a subtest do not know they are in todo given the context is hidden by `Test::Stream`.
