### PR TITLE
Fix undefined sub name, clash with Test::Builder::Level

### DIFF
--- a/META.json
+++ b/META.json
@@ -4,7 +4,7 @@
       "Tokuhiro Matsuno <tokuhirom AAJKLFJEF@ GMAIL COM>"
    ],
    "dynamic_config" : 0,
-   "generated_by" : "Minilla/v2.1.1, CPAN::Meta::Converter version 2.141520",
+   "generated_by" : "Minilla/v2.3.0, CPAN::Meta::Converter version 2.141520",
    "license" : [
       "perl_5"
    ],
@@ -68,16 +68,16 @@
    "release_status" : "unstable",
    "resources" : {
       "bugtracker" : {
-         "web" : "https://github.com/tokuhirom/Test-Pretty/issues"
+         "web" : "https://github.com/aanari/Test-Pretty/issues"
       },
-      "homepage" : "https://github.com/tokuhirom/Test-Pretty",
+      "homepage" : "https://github.com/aanari/Test-Pretty",
       "repository" : {
          "type" : "git",
-         "url" : "git://github.com/tokuhirom/Test-Pretty.git",
-         "web" : "https://github.com/tokuhirom/Test-Pretty"
+         "url" : "git://github.com/aanari/Test-Pretty.git",
+         "web" : "https://github.com/aanari/Test-Pretty"
       }
    },
-   "version" : "0.30",
+   "version" : "0.31",
    "x_contributors" : [
       "Kenichi Ishigaki <ishigaki@cpan.org>",
       "mattn <mattn.jp@gmail.com>",

--- a/lib/Test/Pretty.pm
+++ b/lib/Test/Pretty.pm
@@ -2,7 +2,7 @@ package Test::Pretty;
 use strict;
 use warnings;
 use 5.008001;
-our $VERSION = '0.30';
+our $VERSION = '0.31';
 
 use Test::Builder 0.82;
 use Term::Encoding ();
@@ -198,7 +198,6 @@ sub _ok {
     if (defined($line)) {
         $src_line = $get_src_line->($filename, $line);
     } else {
-        $self->diag(Carp::longmess("\$Test::Builder::Level is invalid. Testing library you are using is broken. : $Test::Builder::Level"));
         $src_line = '';
     }
 
@@ -272,7 +271,7 @@ ERR
     $out .= "\n";
 
     # Dont print 'ok's for subtests. It's not pretty.
-    $self->_print($out) unless $sub =~/subtest/ and $test;
+    $self->_print($out) unless $sub and $sub =~/subtest/ and $test;
 
     unless($test) {
         my $msg = $self->in_todo ? "Failed (TODO)" : "Failed";


### PR DESCRIPTION
This pull request fixes the following erroneous warning output that occurs with more recent versions of Test::Builder, and allows Test::Pretty to work correctly:

> $Test::Builder::Level is invalid. Testing library you are using is broken. : 4 at /Users/ali/perl5/perlbrew/perls/perl-5.14.2/lib/site_perl/5.14.2/Test/Warnings.pm line 134.
>        Test::Warnings::had_no_warnings("no (unexpected) warnings (via done_testing)") called at /Users/ali/perl5/perlbrew/perls/perl-5.14.2/lib/site_perl/5.14.2/Test/Warnings.pm line 101
>        Test::Warnings::**ANON**(Test::Builder=HASH(0x7fd284000f90)) called at /Users/ali/perl5/perlbrew/perls/perl-5.14.2/lib/site_perl/5.14.2/Test/More.pm line 220
>        Test::More::done_testing() called at t/14-cron-jobs/10-search-indexer.t line 46
>  Use of uninitialized value $sub in pattern match (m//) at /Users/ali/perl5/perlbrew/perls/perl-5.14.2/lib/site_perl/5.14.2/Test/Pretty.pm line 275.

I tested the 0.31 tarball locally and everything works fine, and it passes all existing tests in the suite.

> ✓  no (unexpected) warnings (via done_testing)
