### PR TITLE
Skip on Windows to avoid a segfault

### DIFF
--- a/t/fork.t
+++ b/t/fork.t
@@ -4,16 +4,22 @@ use utf8;
 use Test::Pretty;
 use Test::More;
 
-ok 1;
-my $pid = fork();
-die "Cannot fork: $!" if not defined $pid;
-if ($pid == 0) {
-    # child
-    exit;
-} else {
-    # parent
-    waitpid $pid, 0;
-    is($?, 0);
+SKIP: {
+    $^O eq 'MSWin32'
+        and skip 'This is known to crash on Windows. See Issue #26', 1;
+
+    ok 1;
+
+    my $pid = fork();
+    die "Cannot fork: $!" if not defined $pid;
+    if ($pid == 0) {
+        # child
+        exit;
+    } else {
+        # parent
+        waitpid $pid, 0;
+        is($?, 0);
+    }
 }
 
 done_testing;


### PR DESCRIPTION
This is an issue deep in perl itself, due to encoding+fork. See Issue #26