### PR TITLE
Print skip_all plan using _print() to include indents

### DIFF
--- a/lib/Test/Pretty.pm
+++ b/lib/Test/Pretty.pm
@@ -182,7 +182,7 @@ sub _skip_all {
 
     $self->{Skip_All} = $self->parent ? $reason : 1;
 
-    printf("1..0 # SKIP %s\n", $reason);
+    $self->_print("1..0 # SKIP" . " $reason");
     $SHOW_DUMMY_TAP = 0;
     if ( $self->parent ) {
         die bless {} => 'Test::Builder::Exception';

--- a/t/plx/subtests_skip.plx
+++ b/t/plx/subtests_skip.plx
@@ -1,0 +1,15 @@
+use strict;
+use warnings;
+use utf8;
+use Test::More;
+
+subtest 'x' => sub {
+   plan skip_all => 'Beep Boop';
+};
+
+subtest 'y' => sub {
+   plan skip_all => 'I do what I want';
+};
+
+done_testing;
+

--- a/t/subtests_skip.t
+++ b/t/subtests_skip.t
@@ -1,0 +1,18 @@
+use strict;
+use warnings;
+use utf8;
+use Test::More;
+use t::Util;
+
+my $tap = run_test('t/plx/subtests_skip.plx');
+exit_status_is(0);
+
+my $result = parse_tap($tap);
+TODO: {
+    local $TODO = 'plans are inaccurate';
+    is( $result->passed, $result->plan, 'plan == passed tests' );
+}
+ok(!$result->has_problems, 'has no problems');
+
+done_testing;
+


### PR DESCRIPTION
This means the `SKIP` wont affect the exit code of the test if multiple
`SKIP`s are found. This fixes @shoichikaji's situation in #21 

Also fixes @preaction's situation in #21.

Ultimately this was only one layer to the problems in #21. In fixing it, I also discovered the number of passed tests doesn't match the number planned in the new `t/subtests_skip.t`. This is due to the fact that `plan skip_all` in any context removes the dummy tap at the of the tests.