### PR TITLE
Conditionally load Win32::Console::ANSI

### DIFF
--- a/lib/Test/Pretty.pm
+++ b/lib/Test/Pretty.pm
@@ -5,7 +5,11 @@ use 5.008001;
 our $VERSION = '0.31';
 
 use Test::Builder 0.82;
+
+# Conditionally load Windows Term encoding
+use if $^O eq 'MSWin32', 'Win32::Console::ANSI';
 use Term::Encoding ();
+
 use File::Spec ();
 use Term::ANSIColor ();
 use Test::More ();


### PR DESCRIPTION
To support ANSI escape sequences on Win32's `cmd.exe` we can just conditionally load `Win32::Console::ANSI`. This does not solve the issue of utf8 support however.

Solves #32 